### PR TITLE
Fixes #61: Feat: Make child's root comment collapseable

### DIFF
--- a/src/features/collapse-root-comment.js
+++ b/src/features/collapse-root-comment.js
@@ -1,0 +1,58 @@
+import {getAllComments} from '../libs/dom-utils';
+import {paths} from '../libs/paths';
+
+function getCommentIndentation(element) {
+	const indentation = element.querySelector('.ind img').width / 40;
+	return indentation;
+}
+
+function elementPosition(el) {
+	const bodyRect = document.body.getBoundingClientRect();
+	const rect = el.getBoundingClientRect();
+	const top = rect.top - bodyRect.top;
+	return { x: rect.left, y: top };
+}
+
+async function init(metadata) {
+	const comments = getAllComments();
+	let currentRootComment;
+	
+	for (const comment of comments) {
+
+		const indentLevel = getCommentIndentation(comment);
+		
+		if (indentLevel === 0) {
+			currentRootComment = comment;
+			continue;
+		}
+		
+		const inst_currentRootComment = currentRootComment;
+		const toggle = document.createElement('a');
+		
+		toggle.innerText = '[collapse root]';
+		toggle.href = 'javascript:void(0)';
+		toggle.classList.add('__rhn__collapse-root-comment');
+		toggle.addEventListener('click', () => {
+			inst_currentRootComment.querySelector('a.togg').click();
+			const { x, y } = elementPosition(inst_currentRootComment);
+			window.scrollTo(x, y);
+		});
+		
+		comment.querySelector('span.comhead').append(toggle);
+		
+	}
+	
+	return true;
+}
+
+const details = {
+	id: 'collapse-root-comment',
+	pages: {
+		include: paths.comments,
+		exclude: []
+	},
+	loginRequired: false,
+	init
+};
+
+export default details;

--- a/src/features/collapse-root-comment.js
+++ b/src/features/collapse-root-comment.js
@@ -10,38 +10,36 @@ function elementPosition(el) {
 	const bodyRect = document.body.getBoundingClientRect();
 	const rect = el.getBoundingClientRect();
 	const top = rect.top - bodyRect.top;
-	return { x: rect.left, y: top };
+	return {x: rect.left, y: top};
 }
 
-async function init(metadata) {
+async function init() {
 	const comments = getAllComments();
 	let currentRootComment;
-	
-	for (const comment of comments) {
 
+	for (const comment of comments) {
 		const indentLevel = getCommentIndentation(comment);
-		
+
 		if (indentLevel === 0) {
 			currentRootComment = comment;
 			continue;
 		}
-		
-		const inst_currentRootComment = currentRootComment;
+
+		const instCurrentRootComment = currentRootComment;
 		const toggle = document.createElement('a');
-		
+
 		toggle.innerText = '[collapse root]';
 		toggle.href = 'javascript:void(0)';
 		toggle.classList.add('__rhn__collapse-root-comment');
 		toggle.addEventListener('click', () => {
-			inst_currentRootComment.querySelector('a.togg').click();
-			const { x, y } = elementPosition(inst_currentRootComment);
+			instCurrentRootComment.querySelector('a.togg').click();
+			const {x, y} = elementPosition(instCurrentRootComment);
 			window.scrollTo(x, y);
 		});
-		
+
 		comment.querySelector('span.comhead').append(toggle);
-		
 	}
-	
+
 	return true;
 }
 

--- a/src/libs/initialise.js
+++ b/src/libs/initialise.js
@@ -5,6 +5,7 @@ import auto_refresh from '../features/auto-refresh';
 import change_dead_comments_color from '../features/change-dead-comments-color';
 import click_comment_indent_to_toggle from '../features/click-comment-indent-to-toggle';
 import click_rank_to_vote_unvote from '../features/click-rank-to-vote-unvote';
+import collapse_root_comment from '../features/collapse-root-comment';
 import comments_ui_tweaks from '../features/comments-ui-tweaks';
 import fetch_submission_title_from_url from '../features/fetch-submission-title-from-url';
 import hide_read_stories from '../features/hide-read-stories';
@@ -62,6 +63,7 @@ const featureList = [
 	reply_without_leaving_page,
 	preview_and_set_top_bar_color,
 	show_similar_submissions,
+	collapse_root_comment,
 
 	// Options bar (order matters)
 	sort_stories,


### PR DESCRIPTION
Adds a [collapse root] button on child comments, which collapses that comment's root.

Closes #61 