### PR TITLE
fix: Gracefully fail when getUserData fetch returns HTTP 503

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -87,6 +87,7 @@ export function getUserData(path) {
     let actualTopBar = topBarElements[0];
     let topcolor = "#ff6600";
     if (
+      actualTopBar &&
       actualTopBar.children.length === 1 &&
       actualTopBar.children[0].tagName === "IMG"
     ) {


### PR DESCRIPTION
I have noticed the same issue described in #102 where the extension is sometimes stuck in the loading wheel phase. After some playing around, it looks like the problem happens when the `getUserData` fetch returns HTTP response status code 503 which sometimes happens with HackerNews if you refresh quickly or open a lot of links at once. The fetched page looks like this:

![image](https://user-images.githubusercontent.com/3049847/155235793-4e4db8df-198b-4cc6-ac92-d9d316ff81f8.png)

Because of the 503 page, the resulting `topBarElements` is empty and `actualTopBar` is set to `undefined` which leads to an `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'children')` on line 90 of the `utils.js` file. 

## Steps to reproduce
 1. Put a breakpoint on line 3080 in file refined-hacker-news.js.
 2. Refresh https://news.ycombinator.com/news a couple of times quickly.
 3. At some point `actualTopBar` will become `undefined`. 