### PR TITLE
Better Dark Mode Preset CSS

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -41,13 +41,20 @@ for (const link of links) {
 // Custom CSS presets
 const cssPresets = {
   darkMode: `
-		body {
-			background-color: black !important;
-			filter: invert(90%) hue-rotate(180deg) !important;
-		}
-		.__rhn__profile-dropdown {
-			background-color: #f6f6ef !important;
-		}
+	html, body, tbody, #pagespace, field, textarea {
+		background-color: black !important;
+		color: #fff !important;
+	}
+	p, td, .comment, .commtext, a {
+		color: #fff !important;
+	}
+	pre {
+		background-color: #333 !important;
+		color: #fff !important;
+	}
+	.__rhn__profile-dropdown {
+		background-color: #f6f6ef !important;
+	}
 	`,
 };
 


### PR DESCRIPTION
The existing dark mode preset uses a filter to simluate dark mode, which noticably degrades text rendering in Edge/Windows (and possible other places).
This replaces that with CSS that just sets element colors , which renders fine on Egde/Windows - and should work everywhere without issues.