### PR TITLE
Fix outdated openCommentsInNewTab selector

### DIFF
--- a/src/features/open-story-links-in-new-tab.js
+++ b/src/features/open-story-links-in-new-tab.js
@@ -2,7 +2,7 @@ function init(metadata) {
   const links = [
     ...document.querySelectorAll("span.titleline a"),
     ...(metadata.options.openCommentsInNewTab
-      ? document.querySelectorAll("table.itemlist td.subtext > a:last-child")
+      ? document.querySelectorAll("table.itemlist td.subtext > span.subline > a:last-child")
       : []),
   ];
   if (links.length === 0) {


### PR DESCRIPTION
# Brief
This PR alters the CSS selector used for the `openCommentsInNewTab` option to account for the new-ish `span.subline` element added as the "comments" link's parent. This resolves `openCommentsInNewTab` opening comments pages in the same tab.